### PR TITLE
Fix release configuration for proper version management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,18 @@
 plugins {
     java
     alias(libs.plugins.spotless)
+    alias(libs.plugins.release)
 }
 
 val catalog = libs
+
+release {
+    newVersionCommitMessage.set("[Gradle Release Plugin] - [skip ci] new version commit: ")
+    tagTemplate.set("v\$version")
+    git {
+        requireBranch.set("master")
+    }
+}
 
 allprojects {
     apply(plugin = catalog.plugins.spotless.get().pluginId)

--- a/compile/build.gradle.kts
+++ b/compile/build.gradle.kts
@@ -3,15 +3,6 @@ plugins {
     id("java-gradle-plugin")
     alias(libs.plugins.gradle.plugin.publish)
     alias(libs.plugins.spotless)
-    alias(libs.plugins.release)
-}
-
-configure<net.researchgate.release.ReleaseExtension> {
-    newVersionCommitMessage.set("[Gradle Release Plugin] - [skip ci] new version commit: ")
-    tagTemplate.set("v\$version")
-    git {
-        requireBranch.set("master")
-    }
 }
 
 gradlePlugin {


### PR DESCRIPTION
## Summary
- Move release plugin configuration from compile/ to root project
- Consolidate release settings at the top level for better version management
- Ensure release process works correctly across the entire project

## Test plan
- [ ] Verify build still works: `./gradlew build`
- [ ] Test release configuration on master branch
- [ ] Confirm version management works properly

🤖 Generated with [Claude Code](https://claude.ai/code)