### PR TITLE
Fix sourcepath configuration to preserve existing values

### DIFF
--- a/compile/src/main/groovy/org/seasar/doma/gradle/compile/KotlinCompileConfigurator.groovy
+++ b/compile/src/main/groovy/org/seasar/doma/gradle/compile/KotlinCompileConfigurator.groovy
@@ -7,31 +7,35 @@ import org.gradle.api.tasks.SourceSet
  * Configures Kotlin/KAPT compilation tasks for Doma annotation processing.
  */
 class KotlinCompileConfigurator {
-    
+
     private static final String KOTLIN_KAPT_PLUGIN_ID = 'kotlin-kapt'
     private static final String KAPT_EXTENSION_NAME = 'kapt'
     private static final String SOURCE_PATH_OPTION = '--source-path'
     private static final String PARAMETERS_OPTION = '-parameters'
-    
+
     private final Project project
-    
+
     KotlinCompileConfigurator(Project project) {
         this.project = Objects.requireNonNull(project)
     }
-    
+
     void configure(SourceSet sourceSet) {
         project.plugins.withId(KOTLIN_KAPT_PLUGIN_ID) {
             configureKapt(sourceSet)
         }
     }
-    
+
     private void configureKapt(SourceSet sourceSet) {
         def kapt = project.extensions.getByName(KAPT_EXTENSION_NAME)
         def resourceDirs = sourceSet.resources.srcDirs
-        def sourcePath = resourceDirs.join(File.pathSeparator)
+        def newSourcepath = resourceDirs.join(File.pathSeparator)
+        def currentSourcepath = kapt.javacOptions[SOURCE_PATH_OPTION]
+        def sourcepath = currentSourcepath == null
+                ? newSourcepath
+                : currentSourcepath + File.pathSeparator + newSourcepath
 
         kapt.javacOptions {
-            option SOURCE_PATH_OPTION, sourcePath
+            option SOURCE_PATH_OPTION, sourcepath
             option PARAMETERS_OPTION, ''
         }
     }

--- a/compile/src/main/java/org/seasar/doma/gradle/compile/JavaCompileConfigurator.java
+++ b/compile/src/main/java/org/seasar/doma/gradle/compile/JavaCompileConfigurator.java
@@ -29,7 +29,11 @@ class JavaCompileConfigurator {
         __ -> {
           var resourceDirs = sourceSet.getResources().getSrcDirs();
           var options = javaCompile.getOptions();
-          options.setSourcepath(project.files(resourceDirs));
+          var newSourcepath = project.files(resourceDirs);
+          var currentSourcepath = options.getSourcepath();
+          var sourcepath =
+              currentSourcepath == null ? newSourcepath : currentSourcepath.plus(newSourcepath);
+          options.setSourcepath(sourcepath);
           options.getCompilerArgs().add(PARAMETERS_COMPILER_ARG);
         });
   }


### PR DESCRIPTION
## Summary
- Modified JavaCompileConfigurator and KotlinCompileConfigurator to append resource directories to existing sourcepath instead of replacing it
- Ensures compatibility with projects that have custom sourcepath configurations
- Maintains backward compatibility while fixing issues with custom source sets

## Test plan
- [ ] Verify existing tests pass
- [ ] Test with projects that have custom sourcepath configurations
- [ ] Confirm resource directories are correctly added to compilation classpath

🤖 Generated with [Claude Code](https://claude.ai/code)