### PR TITLE
Fix release build configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,14 @@
 rootProject.name = "doma-compile-plugin"
 
-pluginManagement {
-    includeBuild("compile")
-}
+val releaseVersion = settings.startParameter.projectProperties["release.releaseVersion"]
 
-include("compile-java-test")
-include("compile-kotlin-test")
-include("compile-mix-test")
+if (releaseVersion != null) {
+    include("compile")
+} else {
+    pluginManagement {
+        includeBuild("compile")
+    }
+    include("compile-java-test")
+    include("compile-kotlin-test")
+    include("compile-mix-test")
+}


### PR DESCRIPTION
## Summary
- Modified `settings.gradle.kts` to conditionally configure the build based on whether a release is in progress
- When `release.releaseVersion` property is set (during release), only the `compile` module is included
- Otherwise, uses the standard configuration with `includeBuild` and test modules

## Test plan
- [x] Verify normal builds work without release property
- [x] Verify release builds work with release property set
- [ ] CI workflow should pass for both scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)