### PR TITLE
Remove gradle from renovate ignoreDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "extends": [
     "github>domaframework/renovate-config"
-  ],
-  "ignoreDeps": [
-    "gradle"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `ignoreDeps` configuration for gradle from renovate.json
- Allow renovate to manage Gradle version updates automatically

## Test plan
- [ ] Verify renovate configuration is valid
- [ ] Confirm renovate can now detect and propose Gradle updates

🤖 Generated with [Claude Code](https://claude.ai/code)