### PR TITLE
Fix issue where Gradle configuration cache didn’t work

### DIFF
--- a/compile/src/main/java/org/seasar/doma/gradle/compile/JavaCompileConfigurator.java
+++ b/compile/src/main/java/org/seasar/doma/gradle/compile/JavaCompileConfigurator.java
@@ -25,14 +25,13 @@ class JavaCompileConfigurator {
   }
 
   private void configureJavaCompile(SourceSet sourceSet, JavaCompile javaCompile) {
+    var resourceDirs = project.files(sourceSet.getResources().getSrcDirs());
     javaCompile.doFirst(
         __ -> {
-          var resourceDirs = sourceSet.getResources().getSrcDirs();
           var options = javaCompile.getOptions();
-          var newSourcepath = project.files(resourceDirs);
           var currentSourcepath = options.getSourcepath();
           var sourcepath =
-              currentSourcepath == null ? newSourcepath : currentSourcepath.plus(newSourcepath);
+              currentSourcepath == null ? resourceDirs : currentSourcepath.plus(resourceDirs);
           options.setSourcepath(sourcepath);
           options.getCompilerArgs().add(PARAMETERS_COMPILER_ARG);
         });


### PR DESCRIPTION
gradle 9以降`gradle init`でconfiguration cacheがデフォルトで有効になり、
手元の環境でぬるぽになったので修正しました。

