### PR TITLE
[codex] Remove REPO_ACCESS_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
- 
+    permissions:
+      contents: write
+
     steps:
       - name: Assign input version
         if: github.event.inputs.version != null
@@ -46,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          fetch-depth: 0
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
## Summary
- remove `REPO_ACCESS_TOKEN` usage from the release workflow
- use the default `GITHUB_TOKEN` with `contents: write` for release commits and tags
- keep the existing `workflow_dispatch` release flow and the subsequent publish flow unchanged

## Why
The release workflow only needs repository write permissions for its release commit/tag operations. Using the default GitHub Actions token avoids maintaining a separate PAT while preserving the existing release-to-publish behavior.

## Impact
The release workflow no longer depends on `secrets.REPO_ACCESS_TOKEN`. Release remains manually triggered with `workflow_dispatch`, and the Maven publish path triggered by the release push is unchanged.

## Verification
- `git diff --check`
- YAML parse check for `.github/workflows/release.yml`